### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 This extension demonstrates how to perform checks against links in a Markdown document during editing. Specifically, this extension:
 
 1. Extracts all links from the document (both inline and reference links, but not HTML links,) using a regular expression
-2. Identifies which links are HTTP/S
-3. Checks the HTTP/S URLs to see if they reference a language specific version of a URL by checking for a pattern of "LC-CC", where LC is a language code and CC is a country code. For example, "en-us". Ideally want to point to a generic URL that will route viewers to language specific pages based on the browser language setting. So these links are reported as errors.
-4. Checks the HTTP/S URLs to see if they return a 404, and reports these as errors.
+2. Checks the HTTP/S URLs to see if they reference a language specific version of a URL by checking for a pattern of "LC-CC", where LC is a language code and CC is a country code. For example, "en-us". Ideally want to point to a generic URL that will route viewers to language specific pages based on the browser language setting. So these links are reported as errors.
 
-DISCLAIMER: This is a work in progress, and not everything works yet.
+TODO
+
+* Check for broken links: This took too long to check for every change to the document, so it's now tied to Alt+L. But the code isn't active yet, as I'm waiting on examples/guidance on using outputChannels or some other reporting mechanism.
 

--- a/extension.ts
+++ b/extension.ts
@@ -78,32 +78,15 @@ class LinkChecker {
                         return isCountryCodeLink(link, this._uri);
                         // Then, when they are all done..
                     }));
-                    
-                    // Find the links that are only HTTP/s URIs
-                    let httpLinks = links.filter(value => isHttpLink(value.address));
-                    // Iterate over the array of HTTP/s linnks and get an array of promises
-                    let brokenLinkPromise = Promise.all<Diagnostic>(httpLinks.map((link): Promise<Diagnostic> => {
-                        let countryCodeDiag = isCountryCodeLink(link, this._uri);
-                        // For each link, generate a promise to return a diagnostic
-                        if(isHttpLink)
-                            return getBrokenLinkPromise(link, this._uri);
-                        // Then, when all the promises have completed
-                    }));
-                    
                     // Finally, let's complete the promise for country code...
                     countryCodePromise.then((countryCodeDiag) => {
-                        // And broken links...
-                        brokenLinkPromise.then((brokenLinkDiag) => {
-                            // And le's combine the array of diagnostics
-                            let allDiag = countryCodeDiag.concat(brokenLinkDiag);
                             // Then filter out null ones
-                            let filteredDiag = allDiag.filter(diagnostic => diagnostic != null);
+                            let filteredDiag = countryCodeDiag.filter(diagnostic => diagnostic != null);
                             // Then dispose of current diags
                             this.disposeCurrentDiagnostics;
                             // Then add the new ones
                             this._currentDiagnostics = languages.addDiagnostics(filteredDiag);
                         })
-                    })
                 }).catch(); // do nothing; no links were found
             }
         } catch(err) {
@@ -115,6 +98,42 @@ class LinkChecker {
             }
             throw err;
         }
+    }
+}
+
+// Check for broken links
+/*
+* This is where we check for broken links by actually requesting the link.
+* This took too long to perform in real time as the user changes the document,
+* so now it's triggered by Alt+L and the user will wait around for the results
+*/
+function checkBrokenLinks() {
+    let editor = window.getActiveTextEditor;
+    if(!editor) {
+        return;
+    }
+    try {
+        //TBD waiting on info for using outputChannel
+        
+        // Find the links that are only HTTP/s URIs
+                    // let httpLinks = links.filter(value => isHttpLink(value.address));
+                    // Iterate over the array of HTTP/s linnks and get an array of promises
+                    // let brokenLinkPromise = Promise.all<Diagnostic>(httpLinks.map((link): Promise<Diagnostic> => {
+                    //     let countryCodeDiag = isCountryCodeLink(link, this._uri);
+                    //     // For each link, generate a promise to return a diagnostic
+                    //     if(isHttpLink)
+                    //         return getBrokenLinkPromise(link, this._uri);
+                    //     // Then, when all the promises have completed
+                    // }));
+                    
+    } catch(err) {
+        let message: string=null;
+        if(typeof err.message==='string' || err.message instanceof String) {
+            message = <string>err.message;
+            message = message.replace(/\r?\n/g, ' ');
+            throw new Error(message);
+        }
+        throw err;
     }
 }
 
@@ -234,6 +253,9 @@ class LinkCheckController {
     constructor(linkChecker: LinkChecker) {
         this._linkChecker = linkChecker;
         this._linkChecker.diagnoseLinks();
+        
+        // Register a command (broken link check)
+        commands.registerCommand('extension.checkBrokenLinks', checkBrokenLinks);
         
         // Subscribe to selection changes
         let subscriptions: Disposable[] = [];

--- a/package.json
+++ b/package.json
@@ -13,6 +13,21 @@
     "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
     "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
   },
+  "contributes": {
+    "commands": [
+      {
+        "command": "extension.checkBrokenLinks",
+        "title": "Check broken links",
+        "description": "Checks for broken HTTP/s links in a Markdown document"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "extension.checkBrokenLinks",
+        "key": "Alt+L"
+      }
+    ]
+  },
   "devDependencies": {
     "vscode": "*"
   },


### PR DESCRIPTION
refactor to move the expensive broken link checking behind the Alt+L key. Note that it is disabled currently, as I need info on wiring up to OutputChannel or some other reporting mechansim than Diagnostics.
