### PR TITLE
Update country code regex

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -200,7 +200,7 @@ function isCountryCodeLink(link: Link): Diagnostic {
 
 function hasCountryCode(linkToCheck: string): boolean {
     //Regex for country-code
-    let hasCountryCode = linkToCheck.match(/\/[a-z]{2}\-[a-z]{2}\//);
+    let hasCountryCode = linkToCheck.match(/(.com|aka\.ms)\/[a-z]{2}\-[a-z]{2}\//);
     return hasCountryCode ? true : false;
 }
 


### PR DESCRIPTION
A user reported a misidentified language reference in URL so I created this PR to update the country code regex to look for locales after the domain.  

Here's an example [topic ](https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/ad-forest-recovery-single-domain-in-multidomain-recovery) that contains links that reference a service but the extension assumes the string is a country code so it reports that the link contains a language reference:

"Link https://docs.microsoft.com/windows-server/identity/ad-ds/manage/ad-forest-recovery-single-domain-in-multidomain-recovery contains a language reference: undefined"

The updated regex will check for the locale syntax immediately after the domain i.e. https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/ad-forest-recovery-single-domain-in-multidomain-recovery