### PR TITLE
Add a configuration setting to disable the country code rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,25 @@ Open Visual Studio Code and press `F1`; a field will appear at the top of the wi
 
 ![Animated GIF of installing the extension](./images/install.gif)
 
-## Check for country code
+## Rules
 
-Checking for country codes in links happens as you type, and will underline links with green.
+### LNK0001: Check for country code
+
+This rule checks links for language identifiers, such as `en-us`.
 
 ## Check for broken links
 
 To check for broken links, use Alt+L. This will open a new column to the right of the VSCode window and display the status of the links as they are checked.
 
 ## Changes
+
+### 0.3.0
+
+- Added configuration setting to disable the country code rule
+
+### 0.2.0
+
+- Fixed a bug preventing links with parentheses from being correctly parsed
 
 ### 0.1.5
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "HTTP/s and relative link checker",
   "description": "Checks Markdown links for the presence of a country-code as you type and flags as a warning. Checks whether HTTP/s links or relative links are reachable when you press Alt+L.",
   "icon": "images/linkcheckermdicon.png",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "blackmist",
   "galleryBanner": {
     "color": "#0000FF",
@@ -47,7 +47,17 @@
         "command": "extension.generateLinkReport",
         "key": "Alt+L"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "LinkCheckMD",
+      "properties": {
+        "linkcheckmd.enableCountryCodeCheck": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable checking links for hard-coded language identifiers (LNK0001)."
+        }
+      }
+    }
   },
   "devDependencies": {
     "@types/mocha": "^2.2.32",


### PR DESCRIPTION
We use the Docs Authoring Pack as it includes a number of useful extensions for our DocFX sites. However it also contains this package which adds the country-code linting rule, which for our environment is unnecessary.